### PR TITLE
fix(setup): Correct .env file path and source template

### DIFF
--- a/backend/setup.sh
+++ b/backend/setup.sh
@@ -52,9 +52,12 @@ echo "📦 Backend dependencies managed by main project's virtual environment"
 echo "✅ Using shared virtual environment from project root"
 
 # Set up environment variables
-if [ ! -f ".env" ]; then
-    echo "⚙️  Setting up environment configuration..."
-    cp .env.example .env
+PROJECT_ROOT=$(dirname $PWD)
+echo currently in $PWD
+echo copying environment template in $PROJECT_ROOT
+if [ ! -f "$PROJECT_ROOT/.env" ]; then
+    echo "⚙️  Setting up environment configuration in $PROJECT_ROOT ..."
+    cp $PROJECT_ROOT/.env.template $PROJECT_ROOT/.env
     echo "📝 Created .env file from template. Please review and update as needed."
 else
     echo "✅ Environment file already exists"


### PR DESCRIPTION
The `backend/setup.sh` script was creating the `.env` file in the wrong directory (`backend/`) and pointing to an incorrect template file (`.env.example`).

This change corrects the script to:
- Create the `.env` file in the project root for shared configuration.
- Use the correct `/.env.template` as the source file.